### PR TITLE
Add publishing to S3 and update download via cloudfront

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -53,6 +53,8 @@ jobs:
                   fi
               shell: bash
               env:
+                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Building the Electron app for Mac
@@ -62,6 +64,8 @@ jobs:
                   fi
               shell: bash
               env:
+                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   CSC_LINK: developer-id.p12
                   CSC_KEY_PASSWORD: ${{secrets.BCCM_APPLE_DEVELOPER_ID_PASSWORD}}

--- a/electron_builder.js
+++ b/electron_builder.js
@@ -60,6 +60,12 @@ const config = {
         packageCategory: 'game',
     },
     publish: [
+		{
+			provider: 's3',
+			bucket: 'bccm-static',
+			path: 'explorers',
+			acl: null,
+		},
         {
             provider: 'github',
             owner: 'bcc-code',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "publish": "electron-builder --config=electron_builder.js --publish always"
   },
   "author": "BCC Media",
-  "license": "GNU AGPLv3",
+  "license": "(C) 2024 BCC Media",
   "dependencies": {
     "@auth0/auth0-spa-js": "^1.21.0",
     "@microsoft/applicationinsights-web": "^2.8.3",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -40,13 +40,13 @@ const openWindow = (url: string) => {
     handleUrl(url);
     return { action: 'deny' };
   });
-  
+
   async function handleUrl(url: string) {
     const parsedUrl = maybeParseUrl(url);
     if (!parsedUrl) {
       return;
     }
-  
+
     const { protocol } = parsedUrl;
 
     if (protocol !== PRODUCTION_APP_PROTOCOL) {
@@ -58,7 +58,7 @@ const openWindow = (url: string) => {
       }
     }
   }
-  
+
   function maybeParseUrl(value: string): URL | undefined {
     if (typeof value === 'string') {
       try {
@@ -68,7 +68,7 @@ const openWindow = (url: string) => {
         log.error(`Failed to parse url: ${value}`);
       }
     }
-  
+
     return undefined;
   }
 
@@ -199,6 +199,11 @@ if (!gotTheLock) {
     openWindow(initUrl);
 
     // autoUpdater.forceDevUpdateConfig = true
+	autoUpdater.setFeedURL({
+		provider: 'generic',
+		url: 'https://static2.bcc.media/explorers/',
+		channel: 'latest',
+	})
     autoUpdater.checkForUpdatesAndNotify();
   });
 


### PR DESCRIPTION
* Tested updates on MAC
* Curently the bucket is clean
* The base url for downloads is https://static2.bcc.media/explorers/<BINARY>
* The binaries are agressively cached (24h+), while the release channel files (*.yml) have essentialy 0 cache
* Credentials are added to GH
* GH flow has not been tested, but the commands executed locally work