### PR TITLE
feat: select-none to prevent accidental selections

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,7 @@
         <link rel="stylesheet" href="./scss/style.scss" />
     </head>
 
-    <body class="group/body">
+    <body class="group/body select-none">
         <div id="app" class="group/app fixed inset-0 overflow-hidden">
             <header id="header" class="absolute left-0 top-0 hidden w-full">
                 <div class="flex w-full justify-between p-[1%]">


### PR DESCRIPTION
user-select: none; is a better default for apps.
You can easily enable it with `select-text` wherever it makes sense instead. But usually people dont need to select text in a game.